### PR TITLE
Fix version of the package Werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.1.0
 Django==3.2
 environs[django]==9.3.2
 gunicorn==20.*
+Werkzeug==2.3.7


### PR DESCRIPTION
Flask==2.1.0 в своих зависимостях требует Werkzeug, но не конретизирует версию Werkzeug. 

С другой стороны на текущий момент есть Werkzeug 3.0.0 и выше, в которой убрали что-то из обратной совместимости. Поэтмоу Flask==2.1.0 не стартует с Werkzeug 3.0.

Установка конкретной Werkzeug==2.3.7 решает проблему, я проверил